### PR TITLE
Default values the way the docs suggest we do

### DIFF
--- a/lib/Auth/Process/Fticks.php
+++ b/lib/Auth/Process/Fticks.php
@@ -280,8 +280,11 @@ class Fticks extends Auth\ProcessingFilter
             } else {
                 throw new Error\Exception('F-ticks logconfig must be an array');
             }
-        } else {
+        }
+        if (!array_key_exists('facility', $this->logconfig)) {
             $this->logconfig['facility'] = $defaultFacility;
+        }
+        if (!array_key_exists('processname', $this->logconfig)) {
             $this->logconfig['processname'] = $defaultProcessName;
         }
 


### PR DESCRIPTION
The documentation says we default process name and facility, but this doesn't happen if logdest=remote and a logconfig is set to point somewhere other than localhost (as is the case when sending to eduGAIN!). This change makes the behaviour match the documentation.