### PR TITLE
Fix computation of the PN hash

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,32 @@
+# Upgrade notes for simplesamlphp-module-fticks
+
+## Change in PN generation
+
+The `PN` F-Ticks attribute is defined as "A unique identifier for the
+subject involved in the event." To allow statistics to be aggregated,
+this is commonly implemented as a privacy-preserving hash, and
+simplesamlphp-module-fticks is no different.
+
+To ensure uniqueness in multiple identity provider (bridge)
+configurations, simplesamlphp-module-fticks originally
+scoped the generation of the `PN` hash in the same way as the
+[saml:PersistentNameID](https://simplesamlphp.org/docs/stable/saml/nameid.html).
+Unfortunately, in deriving the hashing algorithm, earlier versions
+of this module erroneously included both the source and the
+destination entityId in the calculation of the hash. Where the
+same user logs into several different services, a new PN hash is
+generated for each service. This may result in an overinflation
+in the number of unique principals. This behaviour is compatible
+with the definition but is different to the way e.g.
+[Shibboleth IdP](https://wiki.shibboleth.net/confluence/display/IDP30/FTICKSLoggingConfiguration)
+computes a hash, and may not be what aggregators expect.
+
+In order to align the statistics generation with other software, the
+default behaviour has been changed to create a PN hash that only depends
+on the `identitfyingAttribute` and the `federation`.
+
+People with existing statistics who wish to retain the old behaviour
+should set the `pnHashIsTargeted` option to `both`.
+
+People using bridges where the `identitfyingAttribute` cannot be
+guarenteed unique should set the `pnHashIsTargeted` option to `source`.

--- a/docs/authproc_fticks.md
+++ b/docs/authproc_fticks.md
@@ -33,6 +33,24 @@ The filter supports the following configuration options:
     [supported by PHP](http://php.net/manual/en/function.hash-algos.php)
     can be used.
 
+`pnHashIsTargeted`
+:   When generating the F-Ticks _PN_ attribute, include the source or
+    destination entityId to create a targeted version of the subject. Must
+    be one of the following options:
+
+> * `none` - _PN_ depends only on the `federation` and
+    `identifyingAttribute` (this is the default, and compatible with
+    other implementations).
+> * `source` - _PN_ is targeted based on the SAML source. This is useful
+    for [bridging configurations](bridging) where the `identifyingAttribute`
+    may not be unique.
+> * `destination` - _PN_ is targeted based on the SAML destination
+> * `both` - _PN_ is targeted based on both the SAML source and destination
+    (this option exists to preserve backwards-compatibility, and may
+    lead to overcounting of subjects).
+
+[bridging]: https://simplesamlphp.org/docs/stable/simplesamlphp-advancedfeatures.html#bridging-between-protocols
+
 `exclude`
 :   An array of F-ticks attributes to exclude/filter from the output.
 
@@ -141,7 +159,7 @@ generated/derived:
 
 `PN`
 :   The PN is generated in a similar way too, but completely independently from
-    a [saml:PersistentNameID][5].
+    a [saml:PersistentNameID][5]. Depends on the setting of `pnHashIsTargeted`.
 
 [5]: https://simplesamlphp.org/docs/stable/saml:nameid
 

--- a/src/Auth/Process/Fticks.php
+++ b/src/Auth/Process/Fticks.php
@@ -265,29 +265,23 @@ class Fticks extends Auth\ProcessingFilter
         }
 
         if (array_key_exists('pnHashIsTargeted', $config)) {
-            if (
-                is_string($config['pnHashIsTargeted']) &&
-                in_array($config['pnHashIsTargeted'], ['source', 'destination', 'both', 'none'])
-            ) {
-                $this->pnHashIsTargeted = $config['pnHashIsTargeted'];
-            } else {
-                throw new Error\Exception(
-                    'F-ticks log pnHashIsTargeted must be one of [source, destnation, both, none]',
-                );
-            }
+            Assert::string($config['pnHashIsTargeted'], 'pnHashIsTargeted must be a string');
+            Assert::oneOf(
+                $config['pnHashIsTargeted'],
+                ['source', 'destination', 'both', 'none'],
+                'pnHashIsTargeted must be one of [source, destnation, both, none]',
+            );
+            $this->pnHashIsTargeted = $config['pnHashIsTargeted'];
         }
 
         if (array_key_exists('logdest', $config)) {
-            if (
-                is_string($config['logdest']) &&
-                in_array($config['logdest'], ['local', 'syslog', 'remote', 'stdout', 'errorlog', 'simplesamlphp'])
-            ) {
-                $this->logdest = $config['logdest'];
-            } else {
-                throw new Error\Exception(
-                    'F-ticks log destination must be one of [local, remote, stdout, errorlog, simplesamlphp]',
-                );
-            }
+            Assert::string($config['logdest'], 'F-ticks log destination must be a string');
+            Assert::oneOf(
+                $config['logdest'],
+                ['local', 'syslog', 'remote', 'stdout', 'errorlog', 'simplesamlphp'],
+                'F-ticks log destination must be one of [local, remote, stdout, errorlog, simplesamlphp]',
+            );
+            $this->logdest = $config['logdest'];
         }
 
         /* match SSP config or we risk mucking up the openlog call */

--- a/src/Auth/Process/Fticks.php
+++ b/src/Auth/Process/Fticks.php
@@ -17,7 +17,6 @@ use function array_filter;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
-use function boolval;
 use function constant;
 use function defined;
 use function gethostbyname;
@@ -78,7 +77,7 @@ class Fticks extends Auth\ProcessingFilter
     /** @var array F-ticks attributes to exclude */
     private array $exclude = [];
 
-    /** @var bool Enable legacy handing of PN (for backwards compatibility) */
+    /** @var string Enable legacy handing of PN (for backwards compatibility) */
     private string $pnHashIsTargeted = 'none';
 
 

--- a/tests/src/Auth/Process/FticksTest.php
+++ b/tests/src/Auth/Process/FticksTest.php
@@ -68,7 +68,6 @@ class FticksTest extends TestCase
         Configuration::loadFromArray([
             'secretsalt' => 'secretsalt',
         ], '[ARRAY]', 'simplesaml');
-
     }
 
 
@@ -161,7 +160,12 @@ class FticksTest extends TestCase
      */
     public function testSPwithUserIdLegacyBehaviour(): void
     {
-        $config = ['federation' => 'ACME', 'logdest' => 'stdout', 'identifyingAttribute' => 'eduPersonPrincipalName', 'pnHashIsTargeted' => 'both',];
+        $config = [
+            'federation' => 'ACME',
+            'logdest' => 'stdout',
+            'identifyingAttribute' => 'eduPersonPrincipalName',
+            'pnHashIsTargeted' => 'both',
+        ];
         $request = array_merge(self::$minRequest, self::$spRequest, [
             'Attributes' => [
                 'eduPersonPrincipalName' => [ 'user2@example.net' ],
@@ -186,7 +190,12 @@ class FticksTest extends TestCase
      */
     public function testSPwithUserIdSourceTargeted(): void
     {
-        $config = ['federation' => 'ACME', 'logdest' => 'stdout', 'identifyingAttribute' => 'eduPersonPrincipalName', 'pnHashIsTargeted' => 'source',];
+        $config = [
+            'federation' => 'ACME',
+            'logdest' => 'stdout',
+            'identifyingAttribute' => 'eduPersonPrincipalName',
+            'pnHashIsTargeted' => 'source',
+        ];
         $request = array_merge(self::$minRequest, self::$spRequest, [
             'Attributes' => [
                 'eduPersonPrincipalName' => [ 'user2@example.net' ],
@@ -211,7 +220,12 @@ class FticksTest extends TestCase
      */
     public function testSPwithUserIdSourceTargetedDifferentDest(): void
     {
-        $config = ['federation' => 'ACME', 'logdest' => 'stdout', 'identifyingAttribute' => 'eduPersonPrincipalName', 'pnHashIsTargeted' => 'source',];
+        $config = [
+            'federation' => 'ACME',
+            'logdest' => 'stdout',
+            'identifyingAttribute' => 'eduPersonPrincipalName',
+            'pnHashIsTargeted' => 'source',
+        ];
         $request = array_merge(self::$minRequest, self::$spRequest, [
             'Attributes' => [
                 'eduPersonPrincipalName' => [ 'user2@example.net' ],
@@ -237,7 +251,12 @@ class FticksTest extends TestCase
      */
     public function testSPwithUserIdDestinationTargeted(): void
     {
-        $config = ['federation' => 'ACME', 'logdest' => 'stdout', 'identifyingAttribute' => 'eduPersonPrincipalName', 'pnHashIsTargeted' => 'destination',];
+        $config = [
+            'federation' => 'ACME',
+            'logdest' => 'stdout',
+            'identifyingAttribute' => 'eduPersonPrincipalName',
+            'pnHashIsTargeted' => 'destination',
+        ];
         $request = array_merge(self::$minRequest, self::$spRequest, [
             'Attributes' => [
                 'eduPersonPrincipalName' => [ 'user2@example.net' ],
@@ -263,7 +282,12 @@ class FticksTest extends TestCase
      */
     public function testSPwithUserIdDestinationTargetedDifferentSource(): void
     {
-        $config = ['federation' => 'ACME', 'logdest' => 'stdout', 'identifyingAttribute' => 'eduPersonPrincipalName', 'pnHashIsTargeted' => 'destination',];
+        $config = [
+            'federation' => 'ACME',
+            'logdest' => 'stdout',
+            'identifyingAttribute' => 'eduPersonPrincipalName',
+            'pnHashIsTargeted' => 'destination',
+        ];
         $request = array_merge(self::$minRequest, self::$spRequest, [
             'Attributes' => [
                 'eduPersonPrincipalName' => [ 'user2@example.net' ],

--- a/tests/src/Auth/Process/FticksTest.php
+++ b/tests/src/Auth/Process/FticksTest.php
@@ -54,6 +54,7 @@ class FticksTest extends TestCase
      */
     private static function processFilter(array $config, array $request): array
     {
+        $_SERVER['REQUEST_URI'] = '/simplesaml/'; /* suppress warning from SimpleSAML/Utils/HTTP */
         $filter = new Fticks($config, null);
         $filter->process($request);
         return $request;
@@ -67,6 +68,7 @@ class FticksTest extends TestCase
         Configuration::loadFromArray([
             'secretsalt' => 'secretsalt',
         ], '[ARRAY]', 'simplesaml');
+
     }
 
 
@@ -119,7 +121,162 @@ class FticksTest extends TestCase
         );
         $pattern2 = preg_quote(
             '#AM=' . Constants::AC_UNSPECIFIED
+            . '#PN=d63bb55765af1321b06950abb5f9787cffd05ef271a09b67964f402f3f209cc6#TS=1000#',
+            '/',
+        );
+        $this->expectOutputRegex('/^' . $pattern1 . '[^#]+' . $pattern2 . '$/');
+        $result = self::processFilter($config, $request);
+        $this->assertEquals($request, $result);
+    }
+
+
+    /**
+     */
+    public function testSPwithUserIdDifferentProviders(): void
+    {
+        $config = ['federation' => 'ACME', 'logdest' => 'stdout', 'identifyingAttribute' => 'eduPersonPrincipalName'];
+        $request = array_merge(self::$minRequest, self::$spRequest, [
+            'Attributes' => [
+                'eduPersonPrincipalName' => [ 'user2@example.net' ],
+            ],
+        ]);
+        $request['Destination']['entityid'] = 'https://localhost/idp2';
+        $request['saml:sp:IdP'] = 'https://localhost/saml:sp:IdP2';
+        $pattern1 = preg_quote(
+            'F-TICKS/ACME/1.0#RESULT=OK#AP=https://localhost/saml:sp:IdP2#RP=https://localhost/idp2#CSI=CL',
+            '/',
+        );
+        $pattern2 = preg_quote(
+            '#AM=' . Constants::AC_UNSPECIFIED
+            . '#PN=d63bb55765af1321b06950abb5f9787cffd05ef271a09b67964f402f3f209cc6#TS=1000#',
+            '/',
+        );
+        $this->expectOutputRegex('/^' . $pattern1 . '[^#]+' . $pattern2 . '$/');
+        $result = self::processFilter($config, $request);
+        $this->assertEquals($request, $result);
+    }
+
+
+    /**
+     */
+    public function testSPwithUserIdLegacyBehaviour(): void
+    {
+        $config = ['federation' => 'ACME', 'logdest' => 'stdout', 'identifyingAttribute' => 'eduPersonPrincipalName', 'pnHashIsTargeted' => 'both',];
+        $request = array_merge(self::$minRequest, self::$spRequest, [
+            'Attributes' => [
+                'eduPersonPrincipalName' => [ 'user2@example.net' ],
+            ],
+        ]);
+        $pattern1 = preg_quote(
+            'F-TICKS/ACME/1.0#RESULT=OK#AP=https://localhost/saml:sp:IdP#RP=https://localhost/idp#CSI=CL',
+            '/',
+        );
+        $pattern2 = preg_quote(
+            '#AM=' . Constants::AC_UNSPECIFIED
             . '#PN=e5d066a96d5809a21264e153013c3c793e6574cb77afdfa248ad2cefab9b0451#TS=1000#',
+            '/',
+        );
+        $this->expectOutputRegex('/^' . $pattern1 . '[^#]+' . $pattern2 . '$/');
+        $result = self::processFilter($config, $request);
+        $this->assertEquals($request, $result);
+    }
+
+
+    /**
+     */
+    public function testSPwithUserIdSourceTargeted(): void
+    {
+        $config = ['federation' => 'ACME', 'logdest' => 'stdout', 'identifyingAttribute' => 'eduPersonPrincipalName', 'pnHashIsTargeted' => 'source',];
+        $request = array_merge(self::$minRequest, self::$spRequest, [
+            'Attributes' => [
+                'eduPersonPrincipalName' => [ 'user2@example.net' ],
+            ],
+        ]);
+        $pattern1 = preg_quote(
+            'F-TICKS/ACME/1.0#RESULT=OK#AP=https://localhost/saml:sp:IdP#RP=https://localhost/idp#CSI=CL',
+            '/',
+        );
+        $pattern2 = preg_quote(
+            '#AM=' . Constants::AC_UNSPECIFIED
+            . '#PN=d9b260a0830f4a93b407aaf0a578446880fc8acdc58cd81aecdcde12ec0f8cae#TS=1000#',
+            '/',
+        );
+        $this->expectOutputRegex('/^' . $pattern1 . '[^#]+' . $pattern2 . '$/');
+        $result = self::processFilter($config, $request);
+        $this->assertEquals($request, $result);
+    }
+
+
+    /**
+     */
+    public function testSPwithUserIdSourceTargetedDifferentDest(): void
+    {
+        $config = ['federation' => 'ACME', 'logdest' => 'stdout', 'identifyingAttribute' => 'eduPersonPrincipalName', 'pnHashIsTargeted' => 'source',];
+        $request = array_merge(self::$minRequest, self::$spRequest, [
+            'Attributes' => [
+                'eduPersonPrincipalName' => [ 'user2@example.net' ],
+            ],
+        ]);
+        $request['Destination']['entityid'] = 'https://localhost/idp2';
+        $pattern1 = preg_quote(
+            'F-TICKS/ACME/1.0#RESULT=OK#AP=https://localhost/saml:sp:IdP#RP=https://localhost/idp2#CSI=CL',
+            '/',
+        );
+        $pattern2 = preg_quote(
+            '#AM=' . Constants::AC_UNSPECIFIED
+            . '#PN=d9b260a0830f4a93b407aaf0a578446880fc8acdc58cd81aecdcde12ec0f8cae#TS=1000#',
+            '/',
+        );
+        $this->expectOutputRegex('/^' . $pattern1 . '[^#]+' . $pattern2 . '$/');
+        $result = self::processFilter($config, $request);
+        $this->assertEquals($request, $result);
+    }
+
+
+    /**
+     */
+    public function testSPwithUserIdDestinationTargeted(): void
+    {
+        $config = ['federation' => 'ACME', 'logdest' => 'stdout', 'identifyingAttribute' => 'eduPersonPrincipalName', 'pnHashIsTargeted' => 'destination',];
+        $request = array_merge(self::$minRequest, self::$spRequest, [
+            'Attributes' => [
+                'eduPersonPrincipalName' => [ 'user2@example.net' ],
+            ],
+        ]);
+        $pattern1 = preg_quote(
+            'F-TICKS/ACME/1.0#RESULT=OK#AP=https://localhost/saml:sp:IdP#RP=https://localhost/idp#CSI=CL',
+            '/',
+        );
+        $pattern2 = preg_quote(
+            '#AM=' . Constants::AC_UNSPECIFIED
+            . '#PN=2497368e277bd4d6f848c268292e85cbe3fe4dfd0920b4ac2f5a419f523d4374#TS=1000#',
+            '/',
+        );
+        $this->expectOutputRegex('/^' . $pattern1 . '[^#]+' . $pattern2 . '$/');
+        $result = self::processFilter($config, $request);
+        $this->assertEquals($request, $result);
+        $request['saml:sp:IdP'] = 'https://localhost/saml:sp:IdP2';
+    }
+
+
+    /**
+     */
+    public function testSPwithUserIdDestinationTargetedDifferentSource(): void
+    {
+        $config = ['federation' => 'ACME', 'logdest' => 'stdout', 'identifyingAttribute' => 'eduPersonPrincipalName', 'pnHashIsTargeted' => 'destination',];
+        $request = array_merge(self::$minRequest, self::$spRequest, [
+            'Attributes' => [
+                'eduPersonPrincipalName' => [ 'user2@example.net' ],
+            ],
+        ]);
+        $request['saml:sp:IdP'] = 'https://localhost/saml:sp:IdP2';
+        $pattern1 = preg_quote(
+            'F-TICKS/ACME/1.0#RESULT=OK#AP=https://localhost/saml:sp:IdP2#RP=https://localhost/idp#CSI=CL',
+            '/',
+        );
+        $pattern2 = preg_quote(
+            '#AM=' . Constants::AC_UNSPECIFIED
+            . '#PN=2497368e277bd4d6f848c268292e85cbe3fe4dfd0920b4ac2f5a419f523d4374#TS=1000#',
             '/',
         );
         $this->expectOutputRegex('/^' . $pattern1 . '[^#]+' . $pattern2 . '$/');
@@ -144,7 +301,7 @@ class FticksTest extends TestCase
         );
         $pattern2 = preg_quote(
             '#AM=' . Constants::AC_PASSWORD
-            . '#PN=d844a9a0666bb3990e88f72b8f5c20accbcfa46f7b8a7ab38593bfbbab6e9cbc#TS=',
+            . '#PN=16ed2263078ca90f38708681fcf6628d80e0f91f4b5d743054fe8e185c9e0979#TS=',
             '/',
         );
         $this->expectOutputRegex('/^' . $pattern1 . '[^#]+' . $pattern2 . '\d+#$/');
@@ -218,7 +375,7 @@ class FticksTest extends TestCase
             '/',
         );
         $pattern2 = preg_quote(
-            '#PN=d844a9a0666bb3990e88f72b8f5c20accbcfa46f7b8a7ab38593bfbbab6e9cbc#TS=',
+            '#PN=16ed2263078ca90f38708681fcf6628d80e0f91f4b5d743054fe8e185c9e0979#TS=',
             '/',
         );
         $this->expectOutputRegex('/^' . $pattern1 . '[^#]+' . $pattern2 . '\d+#$/');


### PR DESCRIPTION
While generating some statistics for our annual report, I realised that the way we were calculating the PN hash in the F-Ticks module was leading to massive overcounting. That's because it's effectively as idp-sp-subject thruple rather than just the subject.

This patch corrects the behaviour to make generation more compatible with both the definition and the way Shibboleth IdP [generates things](https://git.shibboleth.net/view/?p=java-identity-provider.git;a=blobdiff;f=idp-conf/src/main/resources/system/conf/audit-system.xml;h=df1c435af9c181c516af95fa6f217aa4b04870fd;hp=1a2b757e6dfb5f925ec230b6281ea77452453345;hb=c4733f83a04dc7df83c54a95f0998127993e374b;hpb=9cab66c8343a3194b416510382edb3a1d9379b26).

The patch deliberately changes existing behaviour, because I think the new behaviour is more correct and aligns with what people expect. Not preserving the bad overcounting behaviour helps things like eduGAIN get better stats.

However, there was a reason that I originally targeted the generation of PN. People (like me) who operate a bridge may not be able to guarantee the uniqueness of an identifying attribute, and so may need to scope it to a particular identity provider. The problem with the original behaviour is it included both source **and** destination, not that it was targetted.

Thus I introduce a new `pnIsTargeted` option to cater for both the bridge case and the legacy behaviour. For completeness, it also allows targeting by destination.